### PR TITLE
Regenerate token for cleanup

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,7 +13,12 @@ GH_TOKEN=$(tr -d "[:space:]" < ${GH_TOKEN_PATH})
 RUNNER_SUFFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 5 | head -n 1)
 RUNNER_NAME="containerNode-${RUNNER_SUFFIX}"
 
-REG_TOKEN=$(curl -sX POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${GH_TOKEN}" https://api.github.com/repos/${GH_OWNER}/${GH_REPOSITORY}/actions/runners/registration-token | jq .token --raw-output)
+reg_token () {
+    local TOKEN=$(curl -sX POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${GH_TOKEN}" https://api.github.com/repos/${GH_OWNER}/${GH_REPOSITORY}/actions/runners/registration-token | jq .token --raw-output)
+    echo -n ${TOKEN}
+}
+
+REG_TOKEN=$(reg_token)
 
 cd /home/docker/actions-runner
 
@@ -21,6 +26,7 @@ cd /home/docker/actions-runner
 
 cleanup() {
     echo "Removing runner..."
+    REG_TOKEN=$(reg_token)
     ./config.sh remove --token ${REG_TOKEN}
 }
 


### PR DESCRIPTION
Registration token will expire after sometime. If the same registration token is used to cleanup after it expires, the cleanup will fail. The solution is to regenerate the registration token immediately before cleanup.